### PR TITLE
Cleanup code and truncate object_references to 300 chars

### DIFF
--- a/source/check_keys_with_wsid.py
+++ b/source/check_keys_with_wsid.py
@@ -1,9 +1,12 @@
+import json
+
 
 def check_keys_with_wsid(errored, errlog_dictionary):
     """check_keys_with_wsid is a function that diligently checks the structure and key present in the errorlog coming from EE2.
     This function is made to accommodate many different structures of errored app logs coming from EE2 with many different key patterns.
     If an EE2 error log has a workspace id that's the first pass, ideally the log should also have a 'job_input' key, a 'job_output' key or
-    an 'error' or 'errormsg' key. There is no standard for error logs coming from EE2 sometimes error messages have the key 'error', sometimes they have the key 'errormsg', and sometimes they have the key 'job_output'.
+    an 'error' or 'errormsg' key. There is no standard for error logs coming from EE2 sometimes error messages have the key 'error',
+    sometimes they have the key 'errormsg', and sometimes they have the key 'job_output'.
     We must account for all structures and sub structures."""
     # First take the workspace ID
     wsid = errored['wsid']
@@ -16,7 +19,7 @@ def check_keys_with_wsid(errored, errlog_dictionary):
     if 'job_input' in errored.keys():
         # Getuseful keys from job input
         if 'params' in errored['job_input'].keys():
-            errlog_dictionary['obj_references'] = errored['job_input']['params']
+            errlog_dictionary['obj_references'] = json.dumps(errored['job_input']['params'], sort_keys=True, indent=4)[0:199]
         # If a EE2 log as a 'job_output' key then that key leads to a nested dictionary that contains the error msg info
         if 'job_output' in errored.keys() and errored['job_output']:
             # the key 'error' in the job_output dictionary can sometimes lead to a dictionary itself
@@ -27,7 +30,8 @@ def check_keys_with_wsid(errored, errlog_dictionary):
             # If the 'error' key does not lead to another nested dictionary than the 'job_output' only contains a 'msg' key with the error msg
             except KeyError:
                 errlog_dictionary['error'] = errored['msg']
-            # Pull traceback key, error code key and name_of_error key (not as helpful a key as one might think: name of error key is just 'job error' or 1 sometimes) from EE2.
+            # Pull traceback key, error code key and name_of_error key (not as helpful a key as one might think: name of error key is
+            # just 'job error' or 1 sometimes) from EE2.
             errlog_dictionary['traceback'] = errored['job_output']['error']['error']
             errlog_dictionary['name_of_error'] = errored['job_output']['error']['name']
             errlog_dictionary['error_code'] = errored['job_output']['error']['code']

--- a/source/check_keys_with_wsid.py
+++ b/source/check_keys_with_wsid.py
@@ -19,7 +19,7 @@ def check_keys_with_wsid(errored, errlog_dictionary):
     if 'job_input' in errored.keys():
         # Getuseful keys from job input
         if 'params' in errored['job_input'].keys():
-            errlog_dictionary['obj_references'] = json.dumps(errored['job_input']['params'], sort_keys=True, indent=4)[0:199]
+            errlog_dictionary['obj_references'] = json.dumps(errored['job_input']['params'], sort_keys=True, indent=4)[0:300]
         # If a EE2 log as a 'job_output' key then that key leads to a nested dictionary that contains the error msg info
         if 'job_output' in errored.keys() and errored['job_output']:
             # the key 'error' in the job_output dictionary can sometimes lead to a dictionary itself

--- a/source/client.py
+++ b/source/client.py
@@ -1,19 +1,26 @@
 import socket
 import json
-import os 
-host = os.environ["ELASTICSEARCH_HOST"]
+import os
+
+host = os.environ.get("ELASTICSEARCH_HOST")
 if (os.environ.get("ELASTICSEARCH_PORT")):
     port = int(os.environ["ELASTICSEARCH_PORT"])
 else:
     port = 9000
-    
+
+if host is not None:
+    print("Elasticsearch endpoint is %s:%d\n" % (host, port))
+else:
+    print("No ELASTICSEARCH_HOST set, no records will be sent to elasticsearch\n")
+
+
 def to_logstash_json(log_d):
 
-    json_data = json.dumps(log_d)
-    json_data += '\n'
+    if host is not None:
+        json_data = json.dumps(log_d)
+        json_data += '\n'
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect((host, port))
-    s.sendall(json_data.encode())
-
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((host, port))
+        s.sendall(json_data.encode())
     return None

--- a/source/get_errored_apps_EE2.py
+++ b/source/get_errored_apps_EE2.py
@@ -62,49 +62,21 @@ def get_errored_apps(start_date=datetime.datetime.combine(yesterday, datetime.da
             # Send the error to helper functions for formatting
             filled_error_dictionary = check_keys_with_wsid.check_keys_with_wsid(errored, errlog_dictionary)
             error_msg = filled_error_dictionary['error']
-            formatted_error_dictionary = filter.filter_error(error_msg, filled_error_dictionary)
-#            print("###############")
-            print("job_id: " +  formatted_error_dictionary["job_id"])
-#            print("app_id: " +  formatted_error_dictionary["app_id"])
-#            print("error_type: " + formatted_error_dictionary["error_type"])
-#            print("error: " +  formatted_error_dictionary['error'])
-#            print("err_prefix: " +  formatted_error_dictionary['err_prefix'])
-#            print("Formatted Error Dictionary: " + str(formatted_error_dictionary))
-            job_array.append(formatted_error_dictionary)
-            c.to_logstash_json(formatted_error_dictionary)
+            error_dictionary = filter.filter_error(error_msg, filled_error_dictionary)
         else:
             # Check if the errormsg key even exist in the log
             if 'errormsg' in errored.keys():
                 errlog_dictionary["error_type"] = "Has errormsg (no ws_id)"
                 error_msg = errlog_dictionary['error'] = errored['errormsg']
                 errlog_dictionary['traceback'] = errored['errormsg']
-                formatted_error_dictionary = filter.filter_error(error_msg, errlog_dictionary)
-                # Job array can be printed at the end of the function for debugging as the array contains all the logs that were sent to Logstash
-#                print("###############")
-                print("job_id: " +  formatted_error_dictionary["job_id"])
-#                print("app_id: " +  formatted_error_dictionary["app_id"])
-#                print("error_type: " + formatted_error_dictionary["error_type"])
-#                print("error: " +  formatted_error_dictionary['error'])
-#                print("err_prefix: " +  formatted_error_dictionary['err_prefix'])
-                job_array.append(formatted_error_dictionary)
-                c.to_logstash_json(formatted_error_dictionary)
+                error_dictionary = filter.filter_error(error_msg, errlog_dictionary)
             else:
                 errlog_dictionary["error_type"] = "NO err_msg no ws_id"
                 errlog_dictionary['err_prefix'] = "_NULL_"
                 errlog_dictionary['category'] = "_NULL_"
-#                print("###############")
-                print("job_id: " +  errlog_dictionary["job_id"])
-#                print("app_id: " +  errlog_dictionary["app_id"])
-#                print("error_type: " +  errlog_dictionary["error_type"])
-#                print("error: " +  errlog_dictionary['error'])
-#                print("err_prefix: " +  errlog_dictionary['err_prefix'])
-                job_array.append(errlog_dictionary)
-                c.to_logstash_json(errlog_dictionary)
-#        print("###############")
-#        print("job_id: " +  errlog_dictionary["job_id"])
-#        print("app_id: " +  errlog_dictionary["app_id"])
-#        print("error_type: " +  errlog_dictionary["error_type"])
-#        print("error: " +  errlog_dictionary['error'])
-#        print("err_prefix: " +  errlog_dictionary['err_prefix'])
+                error_dictionary = errlog_dictionary
+        pprint(error_dictionary)
+        job_array.append(error_dictionary)
+        c.to_logstash_json(error_dictionary)
 
     print("{} Error logs added to Logstash for date range: {} to {}".format(len(job_array), start_date, end_date))

--- a/source/get_errored_apps_EE2.py
+++ b/source/get_errored_apps_EE2.py
@@ -5,7 +5,14 @@ import client as c
 import filter
 import check_keys_with_wsid
 from pprint import pprint
+
+# Token used for querying EE2
 token = os.environ['USER_TOKEN']
+
+# Flag for whether/how much to dump to output as the job runs. Set the env var ERROR_DUMP
+# to turn on a pretty printed dump of the errors as they are processed
+error_dump = os.environ.get("ERROR_DUMP")
+
 ee2 = EE2Client(url='https://kbase.us/services/ee2', token=token)
 yesterday = (datetime.date.today() - datetime.timedelta(days=1))
 
@@ -75,7 +82,8 @@ def get_errored_apps(start_date=datetime.datetime.combine(yesterday, datetime.da
                 errlog_dictionary['err_prefix'] = "_NULL_"
                 errlog_dictionary['category'] = "_NULL_"
                 error_dictionary = errlog_dictionary
-        pprint(error_dictionary)
+        if error_dump:
+            pprint(error_dictionary)
         job_array.append(error_dictionary)
         c.to_logstash_json(error_dictionary)
 


### PR DESCRIPTION
Miscellaneous cleanup of the code including changes to output to stdout, and flattening then truncating object_references into at most a 300 char string. Enormous 10k+ object reference objects are sometimes returned by EE2, and we don't need that pushed into the ES analytics db.